### PR TITLE
Zoomfix

### DIFF
--- a/client/components/gridEntry.jsx
+++ b/client/components/gridEntry.jsx
@@ -4,11 +4,9 @@ import styled from 'styled-components';
 
 const BigImage = styled.img`
 max-width: 100%;
-grid-row-end: span 2;
 margin: auto;
-grid-column-end: span 2;
 transition: transform .2s;
-overflow: hidden;
+overflow: auto;
 cursor: pointer;
 &:hover{
   filter: brightness(85%);
@@ -20,7 +18,7 @@ const SmallImage = styled.img`
 max-width: 99%;
 margin: auto;
 transition: transform .2s;
-overflow: hidden;
+overflow: auto;
 cursor: pointer;
 &:hover{
   filter: brightness(85%);

--- a/client/components/gridEntry.jsx
+++ b/client/components/gridEntry.jsx
@@ -9,9 +9,10 @@ margin: auto;
 grid-column-end: span 2;
 transition: transform .2s;
 overflow: hidden;
+cursor: pointer;
 &:hover{
+  filter: brightness(85%);
   transform: scale(1.02);
-  cursor: pointer;
 }
 `;
 
@@ -20,21 +21,34 @@ max-width: 99%;
 margin: auto;
 transition: transform .2s;
 overflow: hidden;
+cursor: pointer;
 &:hover{
+  filter: brightness(85%);
   transform: scale(1.02);
-  cursor: pointer;
 }
+`;
+
+const BigContainer = styled.div`
+overflow: hidden;
+grid-row-end: span 2;
+grid-column-end: span 2;
+`;
+
+const SmallContainer = styled.div`
+overflow: hidden;
 `;
 
 const GridEntry = (props) => {
   if (props.photo.Image_id % 3 === 1) {
-    return <BigImage src={props.photo.Image_url}
+    return <BigContainer><BigImage src={props.photo.Image_url}
       onClick={() => { props.openCarousel(props.photo.Image_id); }}
-    />;
+    />
+    </BigContainer>;
   }
-  return <SmallImage src={props.photo.Image_url}
+  return <SmallContainer><SmallImage src={props.photo.Image_url}
     onClick={() => { props.openCarousel(props.photo.Image_id); }}
-  />;
+  />
+  </SmallContainer>;
 };
 
 GridEntry.propTypes = {

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -18,9 +18,14 @@ grid-row-gap: 3px;
 grid-column-gap: 2px;
 `;
 
+const Container = styled.div`
+position: relative;
+overflow: auto;
+`;
+
 const OpenButton = styled.span`
 z-index: 1;
-top: 12vw;
+top: 45%;
 right: 5%;
 position: absolute;
 text-align: center;
@@ -132,14 +137,17 @@ class App extends React.Component {
   render() {
     return (
       <div>
-        <div className='grid'>
+        <Container>
           <Grid>
             {this.state.photoArray.map((photo, i) => <GridEntry
               key={i} photo={photo} openCarousel={this.openCarousel.bind(this)}
               closeCarousel={this.closeCarousel.bind(this)}
             />)}
           </Grid>
-        </div>
+            <OpenButton
+              onClick={this.openGridModal.bind(this)}>
+              {this.state.photoArray.length} PHOTOS + </OpenButton>
+        </Container>
         <div>
           <GridModal photoArray={this.state.photoArray}
             openCarousel={this.openCarousel.bind(this)}
@@ -160,9 +168,7 @@ class App extends React.Component {
             closeSymbol="&#x2715;"
             name={this.state.name} />
         </div>
-        <OpenButton
-          onClick={this.openGridModal.bind(this)}>
-          {this.state.photoArray.length} Photos + </OpenButton>
+
       </div>
     );
   }

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -20,7 +20,7 @@ grid-column-gap: 2px;
 
 const Container = styled.div`
 position: relative;
-overflow: auto;
+overflow: hidden;
 `;
 
 const OpenButton = styled.span`
@@ -38,6 +38,10 @@ color: white;
   background-color: rgba(0,0,0,0.7)
 }
 `;
+
+const gridEntryStyle = {
+  overflow: 'hidden',
+};
 
 const apiEndpoint = 'http://localhost:3001/';
 


### PR DESCRIPTION
@cinziaborello @rogen-code @meredith-myers 

Got a pretty little CSS update for the grid of images that appears at the top of the page for this one. Two main changes:

1. The images no longer run over into their neighbors' areas when you hover on them. 
2. The images have a very slight tint effect applied to them when you hover (so tasteful!)

This is pretty subtle (and still needs a little more work), but it looks a lot more like the real zagat page and I'm very happy with it